### PR TITLE
Fix aria2c export format

### DIFF
--- a/KGrabber.user.js
+++ b/KGrabber.user.js
@@ -721,10 +721,10 @@ KG.exporters.aria2c = {
 	requireSamePage: false,
 	requireDirectLinks: true,
 	export: (data) => {
-		var padLength = Math.max(2, data.episodes[data.episodes.length - 1].num.toString().length);
+        var listing = $(".listing a").get().reverse();
 		var str = "";
 		KG.for(data.episodes, (i, obj) => {
-			str += `${obj.grabLink}\n	-o E${obj.num.toString().padStart(padLength, "0")}.mp4\n`;
+			str += `${obj.grabLink}\n out=${listing[obj.num-1].innerText}.mp4\n`;
 		});
 		return str;
 	}

--- a/KGrabber.user.js
+++ b/KGrabber.user.js
@@ -721,10 +721,10 @@ KG.exporters.aria2c = {
 	requireSamePage: false,
 	requireDirectLinks: true,
 	export: (data) => {
-        var listing = $(".listing a").get().reverse();
+		var padLength = Math.max(2, data.episodes[data.episodes.length - 1].num.toString().length);
 		var str = "";
 		KG.for(data.episodes, (i, obj) => {
-			str += `${obj.grabLink}\n out=${listing[obj.num-1].innerText}.mp4\n`;
+			str += `${obj.grabLink}\n	-o E${obj.num.toString().padStart(padLength, "0")}.mp4\n`;
 		});
 		return str;
 	}

--- a/KGrabber.user.js
+++ b/KGrabber.user.js
@@ -721,10 +721,10 @@ KG.exporters.aria2c = {
 	requireSamePage: false,
 	requireDirectLinks: true,
 	export: (data) => {
-		var padLength = Math.max(2, data.episodes[data.episodes.length - 1].num.toString().length);
+		var listing = $(".listing a").get().reverse();
 		var str = "";
 		KG.for(data.episodes, (i, obj) => {
-			str += `${obj.grabLink}\n	-o E${obj.num.toString().padStart(padLength, "0")}.mp4\n`;
+			str += `${obj.grabLink}\n out=${listing[obj.num-1].innerText}.mp4\n`;
 		});
 		return str;
 	}
@@ -752,6 +752,7 @@ mkdir "%title%" > nul\n\n`;
 		return str;
 	}
 }
+
 
 //further options after grabbing, such as converting embed to direct links
 

--- a/src/js/exporters.js
+++ b/src/js/exporters.js
@@ -91,10 +91,10 @@ KG.exporters.aria2c = {
 	requireSamePage: false,
 	requireDirectLinks: true,
 	export: (data) => {
-		var padLength = Math.max(2, data.episodes[data.episodes.length - 1].num.toString().length);
+		var listing = $(".listing a").get().reverse();
 		var str = "";
 		KG.for(data.episodes, (i, obj) => {
-			str += `${obj.grabLink}\n	-o E${obj.num.toString().padStart(padLength, "0")}.mp4\n`;
+			str += `${obj.grabLink}\n out=${listing[obj.num-1].innerText}.mp4\n`;
 		});
 		return str;
 	}


### PR DESCRIPTION
Fix aria2c output format, Change filename format to series episode num - episode name like IDM is (actually just copied it...).  aria2c can work with filenames that has spaces in them.  Replace tab with space to ensure aria2c will handle it properly.

Tested with aria2c 1.33.1 on Ubuntu 18.04.2.

Note: You don't have to take this asis if you don't want to change the way it makes the filenames here.  The primary fix is changing -o to out= (and remove the space) and replace the tab in front of it with a single space.