### PR TITLE
Add standalone downloaders for POSIX and Windows.

### DIFF
--- a/src/js/exporters/curl-shell.js
+++ b/src/js/exporters/curl-shell.js
@@ -15,7 +15,7 @@ const SHEBANG = "#!/use/bin/sh";
 
 const HYDRAX_DOWNLOADER = `
 # downloadHydraXVideo <slug> <output file> [hd|sd]
-downloadHydraXVideo(){	
+downloadHydraXVideo(){
 	url=\`
 		curl "https://ping.idocdn.com/" -d "slug=$1" |
 		sed -r 's/.*"url":"([a-zA-Z0-9=+-]*)".*/\\1/;s/(.*)(.)/\\2\\1/' |

--- a/src/js/exporters/curl-shell.js
+++ b/src/js/exporters/curl-shell.js
@@ -1,0 +1,76 @@
+/**
+ * @typedef {import("kgrabber-types/Status")} Status
+ */
+
+const { LinkTypes, Exporter } = require("kgrabber-types");
+
+module.exports = new Exporter({
+	name: "curl (shell script)",
+	extension: "sh",
+	requireSamePage: false,
+	linkTypes: [LinkTypes.DIRECT, LinkTypes.REFERER],
+}, runExport);
+
+const SHEBANG = "#!/use/bin/sh";
+
+const HYDRAX_DOWNLOADER = `
+# downloadHydraXVideo <slug> <output file> [hd|sd]
+downloadHydraXVideo(){	
+	url=\`
+		curl "https://ping.idocdn.com/" -d "slug=$1" |
+		sed -r 's/.*"url":"([a-zA-Z0-9=+-]*)".*/\\1/;s/(.*)(.)/\\2\\1/' |
+		base64 -id
+	\`;
+
+	if [ "$3" != "sd" ]; then
+		url="www.$url";
+	fi
+
+	curl --insecure "https://$url" -# -C - -H "Referer: https://playhydrax.com/?v=$1" -o "$2";
+}
+`
+.replace(/\t/g, " ".repeat(4));
+// Replace tabs with spaces inside script because pasting tabs might cause issues.
+
+/**
+ * @param {Status} status
+ * @returns {String}
+ */
+
+function runExport(status) {
+	let listing = $(".listing a").get().reverse();
+	
+	let episodes = status.episodes
+		.filter(e => !e.error)
+		.map(e => {
+			return {
+				link: e.grabbedLink,
+				referer: e.processedLink.referer,
+				name: sanitizeFileName(listing[e.episodeNumber - 1].innerText) + ".mp4"
+			}
+		});
+
+	if(episodes.length == 0)
+		return "";
+	
+	let script = [SHEBANG];
+	
+	if(status.serverID == "hydrax")
+		script.push(HYDRAX_DOWNLOADER);
+	
+	for(let {name, link, referer} of episodes)
+		if(status.serverID == "hydrax"){
+			let slug = new URL(link).searchParams.get("v");
+			script.push(`downloadHydraXVideo "${slug}" "${name}"`);
+		}
+		else if(status.linkType == LinkTypes.REFERER)
+			script.push(`curl -# -C - -H "Referer: ${referer}" ${link}" -o "${name}"`);
+		else
+			script.push(`curl -# -C - "${link}" -o "${name}"`);
+	
+	return script.join("\n");
+}
+
+function sanitizeFileName(name, replaceWith = "-"){
+	return name.replace(/[<>:"\/\\|?*]/g, replaceWith);
+}

--- a/src/js/exporters/curl-shell.js
+++ b/src/js/exporters/curl-shell.js
@@ -26,7 +26,7 @@ downloadHydraXVideo(){
 		url="www.$url";
 	fi
 
-	curl --insecure "https://$url" -# -C - -H "Referer: https://playhydrax.com/?v=$1" -o "$2";
+	curl --insecure "https://$url" -# -C - --referer "https://playhydrax.com/?v=$1" -o "$2";
 }
 `
 .replace(/\t/g, " ".repeat(4));
@@ -64,7 +64,7 @@ function runExport(status) {
 			script.push(`downloadHydraXVideo "${slug}" "${name}"`);
 		}
 		else if(status.linkType == LinkTypes.REFERER)
-			script.push(`curl -# -C - -H "Referer: ${referer}" ${link}" -o "${name}"`);
+			script.push(`curl -# -C - --referer "${referer}" "${link}" -o "${name}"`);
 		else
 			script.push(`curl -# -C - "${link}" -o "${name}"`);
 	

--- a/src/js/exporters/index.js
+++ b/src/js/exporters/index.js
@@ -13,6 +13,8 @@ const exporters = [
 	require("./csv"),
 	require("./aria2c"),
 	require("./idmbat"),
+	require("./curl-shell"),
+	require("./iwr-bat")
 ];
 
 /**

--- a/src/js/exporters/iwr-bat.js
+++ b/src/js/exporters/iwr-bat.js
@@ -1,0 +1,94 @@
+/**
+ * @typedef {import("kgrabber-types/Status")} Status
+ */
+
+const { LinkTypes, Exporter } = require("kgrabber-types");
+
+module.exports = new Exporter({
+	name: "Invoke-WebRequest (bat script)",
+	extension: "bat",
+	requireSamePage: false,
+	linkTypes: [LinkTypes.DIRECT, LinkTypes.REFERER],
+}, runExport);
+
+const BAT_HEADER = `
+<# ::
+@setlocal & copy "%~f0" "%TEMP%\%~0n.ps1" >NUL && powershell -NoProfile -ExecutionPolicy Bypass -File "%TEMP%\%~0n.ps1" %*
+@set "ec=%ERRORLEVEL%" & del "%TEMP%\%~0n.ps1"
+@exit /b %ec%
+#>
+`;
+
+const HYDRAX_DOWNLOADER = `
+# downloadHydraXVideo <slug> <output file> [hd|sd]
+function downloadHydraXVideo($1, $2, $3){
+	$progressPreference = "silentlyContinue";
+	
+	$response = Invoke-WebRequest "https://ping.idocdn.com/" \`
+			-UseBasicParsing \`
+			-Method POST \`
+			-Body @{slug = "$1"};
+	
+	$urlBase64 = (ConvertFrom-Json $response.Content).url;
+	
+    $url = [System.Text.Encoding]::UTF8.GetString(
+			[System.Convert]::FromBase64String(
+				$urlBase64.Chars($urlBase64.Length - 1) + $urlBase64.Substring(0, $urlBase64.Length - 1)
+			)
+		);
+	
+	if("$3" -ne "sd"){
+		$url = "www." + $url;
+	}
+	
+	Invoke-WebRequest "https://$url" \`
+		-UseBasicParsing \`
+		-Headers @{Referer = "https://playhydrax.com/?v=$1"} \`
+		-OutFile "$2";
+	
+	$progressPreference = "Continue";
+}
+`;
+
+/**
+ * @param {Status} status
+ * @returns {String}
+ */
+
+function runExport(status) {
+	let listing = $(".listing a").get().reverse();
+	
+	let episodes = status.episodes
+		.filter(e => !e.error)
+		.map(e => {
+			return {
+				link: e.grabbedLink,
+				referer: e.processedLink.referer,
+				name: sanitizeFileName(listing[e.episodeNumber - 1].innerText) + ".mp4"
+			}
+		});
+
+	if(episodes.length == 0)
+		return "";
+	
+	let script = [BAT_HEADER];
+	
+	if(status.serverID == "hydrax")
+		script.push(HYDRAX_DOWNLOADER);
+	
+	for(let {name, link, referer} of episodes)
+		if(status.serverID == "hydrax"){
+			let slug = new URL(link).searchParams.get("v");
+			script.push(`downloadHydraXVideo "${slug}" "${name}"`);
+		}
+		else if(status.linkType == LinkTypes.REFERER)
+			script.push(`Invoke-WebRequest "${link}" -Headers @{Referer = "${referer}"} -OutFile "${name}"`);
+		else
+			script.push(`Invoke-WebRequest "${link}" -OutFile "${name}""`);
+	
+	return script.join("\n");
+}
+
+function sanitizeFileName(name, replaceWith = "-"){
+	return name.replace(/[<>:"\/\\|?*]/g, replaceWith);
+}


### PR DESCRIPTION
Adds standalone downloaders for:
- POSIX systems: only hard requirement is `curl` (obviously) (GNU `sed` and `base64` needed for the HydraX script).
- Windows: no additonal software required except a modern version of Windows 10.

Generates download scripts for direct links and HydraX links.
Also can generate a generic version of referrer links, but it is not currently in use.

Closes #35 

## Notes
- If the curl script is interrupted, it can simply be restarted, and the download will continue from where it stopped.
  Unfortunately, I could not find a way to do this for the bat script.
- The curl (not HydraX) script can easily be parallelize with GNU `parallel`.